### PR TITLE
0.3.0: 28th February 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## \[Unreleased\]
 
+## \[0.3.0\] - 2024-02-28
+
+### Added
+
+  - Add image file name extracting from absolute path
+  - Add optional rgb output
+
+### Changed
+
+  - Change comments to linux kernel-style comments
+  - Improve logging in rgb to hex converting
+  - Improve makefiles
+
+### Fixed
+
+  - After failure in converting rgb to hex, the color is set to #000000
+
 ## \[0.2.0\] - 2024-02-13
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ deps:
 
 $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	strip --remove-section=.note.gnu.build-id --strip-all --strip-unneeded -g $@
 
 # Rule to build object files from source files
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c | $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Ofast -std=gnu11 -static -Wextra -Wall
+CFLAGS = -Ofast -std=gnu11 -static -Wextra -Wall -s -finline-small-functions
 LDFLAGS = -lm -L./src/lib -lparg -llogging
 SRC_DIR = src
 BUILD_DIR = build
@@ -33,7 +33,7 @@ $(TARGET): $(OBJS)
 
 # Rule to build object files from source files
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c | $(BUILD_DIR)
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) $(CFLAGS) -flto -c -o $@ $<
 
 $(BUILD_DIR):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ $(BUILD_DIR):
 	mkdir -p $@
 
 clean:
-	rm -rf $(BUILD_DIR) $(TARGET) $(SRC_DIR)/lib/libparg.a $(SRC_DIR)/lib/liblogging.a $(SRC_DIR)/include/*.c $(SRC_DIR)/include/*.h
+	rm -rf $(BUILD_DIR) $(TARGET) $(SRC_DIR)/lib $(SRC_DIR)/include/*.c $(SRC_DIR)/include/*.h

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ GPLv3](https://img.shields.io/badge/license-GNU%20GPLv3-blue.svg)
 
 `chromasampler-c` calculates the average colour of an image.
 
-It can extract the average colour from images in various formats.
-This makes it useful for tasks such as image analysis, colour-based sorting,
-or generating colour palettes.
+It can extract the average colour from images in various formats. This makes it
+useful for tasks such as image analysis, colour-based sorting, or generating
+colour palettes.
 
 ## Table of Contents
 
@@ -22,6 +22,7 @@ or generating colour palettes.
 To use `chromasampler-c`, follow these steps:
 
 1.  Clone the repository:
+
     ``` console
     git clone https://github.com/walker84837/chromasampler-c.git
     ```
@@ -29,6 +30,7 @@ To use `chromasampler-c`, follow these steps:
 2.  Navigate to the project directory: `cd chromasampler-c`
 
 3.  Compile the program:
+
     ``` console
     make -B
     ```
@@ -45,8 +47,18 @@ input image file using the `-f` option. Here's an example:
   - `-f`: Specify the filename of the input image.
   - `-h`: Display the help message with usage information.
 
-**DISCLAIMER**: (Some) WebP images will, for some reason, cause 
-"undefined behaviour", which is immediately handled.
+The supported image formats are:
+
+  - **JPEG**: baseline & progressive (12 bpc/arithmetic not supported, same as
+    stock IJG lib)
+  - **PNG**: 1/2/4/8/16-bit-per-channel
+  - **TGA**
+  - **BMP**: non-1bpp, non-RLE
+  - **PSD**: composited view only, no extra channels, 8/16 bit-per-channel
+  - **GIF**: \*comp always reports as 4-channel
+  - **HDR**: radiance rgbE format
+  - **PIC**: Softimage PIC
+  - **PNM**: PPM and PGM binary only
 
 ## Roadmap
 
@@ -57,7 +69,8 @@ input image file using the `-f` option. Here's an example:
 
 Contributions are welcome! If you'd like to contribute, please
 
-  - Follow the [Linux kernel coding style](https://docs.kernel.org/process/coding-style.html).
+  - Follow the [Linux kernel coding
+    style](https://docs.kernel.org/process/coding-style.html).
   - Follow the [code of conduct](CODE_OF_CONDUCT.md).
   - If you're proposing new changes, open an issue.
 
@@ -71,10 +84,9 @@ This project is licensed under the [GNU GPLv3](LICENSE.md).
 Feel free to use, contribute, or provide feedback. If you are interested in
 becoming a maintainer, please get in touch.
 
-Where the project is dual-licensed under a public domain license or licenses 
-like the MIT, I'm choosing the public domain licenses.
-I'll give attribution to every external dependency (or code) used in this 
-repository:
+Where the project is dual-licensed under a public domain license or licenses
+like the MIT, I'm choosing the public domain licenses. I'll give attribution to
+every external dependency (or code) used in this repository:
 
   - [parg](https://github.com/jibsen/parg): MIT-0
   - [stb](https://github.com/nothings/stb): Unlicense OR MIT

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ input image file using the `-f` option. Here's an example:
   - `-f`: Specify the filename of the input image.
   - `-r`: Output the average color in RGB format.
   - `-h`: Display the help message with usage information.
+  - The `.img` in image.img refers to one of these formats, which are the 
+    only ones supported as of now.
 
 The supported image formats are:
 
@@ -63,7 +65,6 @@ The supported image formats are:
 
 ## Roadmap
 
-  - Wider image support (especially WebP images).
   - Configuration with [INI](https://github.com/clibs/inih).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ input image file using the `-f` option. Here's an example:
 ```
 
   - `-f`: Specify the filename of the input image.
+  - `-r`: Output the average color in RGB format, along with the one in
+    hexadecimal.
   - `-h`: Display the help message with usage information.
 
 The supported image formats are:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![Licensed under GNU
 GPLv3](https://img.shields.io/badge/license-GNU%20GPLv3-blue.svg)
 
-`chromasampler-c` efficiently calculates the average colour of an image.
+`chromasampler-c` calculates the average colour of an image.
 
-It can extract dominant colour information from images in various formats.
+It can extract the average colour from images in various formats.
 This makes it useful for tasks such as image analysis, colour-based sorting,
 or generating colour palettes.
 
@@ -50,9 +50,8 @@ input image file using the `-f` option. Here's an example:
 
 ## Roadmap
 
-  - Support for WebP images.
+  - Wider image support (especially WebP images).
   - Configuration with [INI](https://github.com/clibs/inih).
-  - Wider image support.
 
 ## Contributing
 
@@ -81,4 +80,4 @@ repository:
   - [stb](https://github.com/nothings/stb): Unlicense OR MIT
   - [pure-sh-bible](https://github.com/dylanaraps/pure-sh-bible): MIT
 
-**NOTE**: Development may slow down or stop in the future.
+**NOTE**: Development *may* slow down or stop in the future.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ input image file using the `-f` option. Here's an example:
 ```
 
   - `-f`: Specify the filename of the input image.
-  - `-r`: Output the average color in RGB format, along with the one in
-    hexadecimal.
+  - `-r`: Output the average color in RGB format.
   - `-h`: Display the help message with usage information.
 
 The supported image formats are:

--- a/src/include/download_deps.sh
+++ b/src/include/download_deps.sh
@@ -4,8 +4,8 @@ deps=(
 	"https://raw.githubusercontent.com/nothings/stb/master/stb_image.h"
 	"https://raw.githubusercontent.com/jibsen/parg/master/parg.h"
 	"https://raw.githubusercontent.com/jibsen/parg/master/parg.c"
-	"https://raw.githubusercontent.com/clibs/inih/master/ini.c"
-	"https://raw.githubusercontent.com/clibs/inih/master/ini.h"
+	# "https://raw.githubusercontent.com/clibs/inih/master/ini.c"
+	# "https://raw.githubusercontent.com/clibs/inih/master/ini.h"
 )
 
 # Usage: basename "path" ["suffix"]

--- a/src/include/download_deps.sh
+++ b/src/include/download_deps.sh
@@ -4,6 +4,8 @@ deps=(
 	"https://raw.githubusercontent.com/nothings/stb/master/stb_image.h"
 	"https://raw.githubusercontent.com/jibsen/parg/master/parg.h"
 	"https://raw.githubusercontent.com/jibsen/parg/master/parg.c"
+	"https://raw.githubusercontent.com/clibs/inih/master/ini.c"
+	"https://raw.githubusercontent.com/clibs/inih/master/ini.h"
 )
 
 # Usage: basename "path" ["suffix"]

--- a/src/logging/Makefile
+++ b/src/logging/Makefile
@@ -1,5 +1,5 @@
 all:
-	gcc -c logging.c -o logging.o
+	gcc -march=native -mtune=native -finline-small-functions -fno-default-inline -O2 -flto -s -c logging.c -o logging.o
 	ar rcs liblogging.a logging.o
 	rm -rf logging.o
 	mv liblogging.a ../lib

--- a/src/main.c
+++ b/src/main.c
@@ -33,8 +33,6 @@ typedef struct {
 	uint64_t blue;
 } rgb_color_t;
 
-bool verbose = false;
-
 char *basename(const char *path)
 {
 	char *dir = (char *)path;
@@ -179,11 +177,15 @@ int main(int argc, char **argv)
 		{0, 0, 0, 0}
 	};
 
+	bool rgb = false;
 	int opt;
-	while ((opt = parg_getopt_long(&ps, argc, argv, "f:h", longopts, NULL)) != -1) {
+	while ((opt = parg_getopt_long(&ps, argc, argv, "rf:h", longopts, NULL)) != -1) {
 		switch (opt) {
 			case 'f':
 				filename = ps.optarg;
+				break;
+			case 'r':
+				rgb = true;
 				break;
 			case 'h':
 				printf("%s: find the average color in an image\n", argv[0]);
@@ -212,11 +214,14 @@ int main(int argc, char **argv)
 		average_rgb.blue
 	);
 
-	printf("rgb(%lu, %lu, %lu)\n",
-		average_rgb.red,
-		average_rgb.green,
-		average_rgb.blue
-	);
+	if (rgb) {
+		printf("rgb(%lu, %lu, %lu)\n",
+			average_rgb.red,
+			average_rgb.green,
+			average_rgb.blue
+		);
+	}
+
 	printf("%s\n", hex_color);
 
 	free(hex_color);

--- a/src/main.c
+++ b/src/main.c
@@ -92,22 +92,17 @@ void rgb_to_hex(char **hex_color, uint8_t red, uint8_t green, uint8_t blue)
 
 	if (snprintf(*hex_color, 8, "#%02x%02x%02x", red, green, blue) != 7) {
 		error("Converting RGB-formatted color to hexadecimal format failed.");
-		warning("Something wrong happened during formatting. Setting the color to #000000");
+		warning("Something wrong happened during color formatting! Setting it to `#000000`.");
 		*hex_color = "#000000";
 	}
-}
-
-bool is_null_or_empty(const char *str)
-{
-	return str == NULL || *str == '\0';
 }
 
 static rgb_color_t calculate_average_rgb(const char *filename)
 {
 	const char *extension = get_file_extension(filename);
 
-	if (is_null_or_empty(extension)) {
-		warning("The image doesn't have a file extension or is `NULL`. Expect errors to happen.");
+	if (extension == NULL || *extension == '\0') {
+		warning("The image doesn't have a file extension. Expect errors to happen.");
 	}
 
 	int width, height, channels;
@@ -120,7 +115,7 @@ static rgb_color_t calculate_average_rgb(const char *filename)
 	char *filename_base = basename(filename);
 
 	if (!image) {
-		fatal_error("Failed to load image '%s'", filename_base);
+		fatal_error("Failed to load image '%s'. The error may be caused by an invalid image or invalid format.", filename_base);
 		exit(EXIT_FAILURE);
 	}
 
@@ -191,6 +186,7 @@ int main(int argc, char **argv)
 				printf("%s: find the average color in an image\n", argv[0]);
 				printf("Usage: %s [-f filename]\n", argv[0]);
 				puts("  -f  file name of the image");
+				puts("  -r  output the color in rgb format");
 				puts("  -h  open this help");
 				exit(EXIT_SUCCESS);
 			default:
@@ -200,21 +196,24 @@ int main(int argc, char **argv)
 	}
 
 	if (filename == NULL) {
-		fatal_error("No image was provided");
+		fatal_error("No image was provided.");
 		exit(EXIT_FAILURE);
 	}
 
 	rgb_color_t average_rgb = calculate_average_rgb(filename);
-	char *hex_color = NULL;
 
-	rgb_to_hex(
-		&hex_color,
-		average_rgb.red,
-		average_rgb.green,
-		average_rgb.blue
-	);
+	if (!rgb) {
+		char *hex_color = NULL;
+		rgb_to_hex(
+			&hex_color,
+			average_rgb.red,
+			average_rgb.green,
+			average_rgb.blue
+		);
 
-	if (rgb) {
+		printf("%s\n", hex_color);
+		free(hex_color);
+	} else {
 		printf("rgb(%lu, %lu, %lu)\n",
 			average_rgb.red,
 			average_rgb.green,
@@ -222,8 +221,5 @@ int main(int argc, char **argv)
 		);
 	}
 
-	printf("%s\n", hex_color);
-
-	free(hex_color);
 	return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -130,8 +130,8 @@ static rgb_color_t calculate_average_rgb(const char *filename)
 	 * consideration leads to counting the colors incorrectly, leading to
 	 * an inaccurate color average.
 	 */
-	if (channels == 4) {
-		warning("4 channels found in '%s', forcing 3 channels.", filename_base);
+	if (channels != 3) {
+		warning("%d channels found in '%s', forcing 3 channels.", channels, filename_base);
 		channels = 3;
 	}
 


### PR DESCRIPTION
## \[0.3.0\] - 2024-02-28

### Added

  - Add image file name extracting from absolute path
  - Add optional RGB output

### Changed

  - Change comments to Linux kernel-style comments
  - Improve logging in RGB to hex converting
  - Improve Makefiles

### Fixed

  - After failure in converting RGB to hex, the colour is set to #000000